### PR TITLE
insert-demos.js 中有一行代码区分中英文 切割路径代码未兼容windows

### DIFF
--- a/lib/insert-demos.js
+++ b/lib/insert-demos.js
@@ -39,7 +39,7 @@ function parseYAML(str) {
 }
 
 function extractI18N(resource) {
-  return resource.split('/').pop().split('.')[0].split('_')[1];
+  return resource.split(path.sep).pop().split('.')[0].split('_')[1];
 }
 
 function isAPIHeader(node) {


### PR DESCRIPTION
windows 系统 路径如果有小数点的话会报错